### PR TITLE
Implement VOLaM scoring with empathy fit calculation

### DIFF
--- a/api/src/services/empathy.test.ts
+++ b/api/src/services/empathy.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { EmpathyService } from './empathy.js';
+
+describe('EmpathyService', () => {
+  let empathyService: EmpathyService;
+
+  beforeEach(() => {
+    empathyService = new EmpathyService();
+  });
+
+  describe('calculateEmpathyFit', () => {
+    it('should return neutral empathy fit for empty stakeholders', () => {
+      const contentTags = { stakeholders: [], topics: [], domain: 'general' };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'default');
+      
+      expect(empathyFit).toBe(0.5);
+    });
+
+    it('should return low empathy fit for unmatched stakeholders', () => {
+      const contentTags = { 
+        stakeholders: ['unknown_stakeholder'], 
+        topics: [], 
+        domain: 'general' 
+      };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'default');
+      
+      expect(empathyFit).toBe(0.2);
+    });
+
+    it('should calculate empathy fit for matched stakeholders with default profile', () => {
+      const contentTags = { 
+        stakeholders: ['general_public', 'experts'], 
+        topics: [], 
+        domain: 'general' 
+      };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'default');
+      
+      // Default profile: general_public: 0.4, experts: 0.3
+      // Average: (0.4 + 0.3) / 2 = 0.35
+      // With stakeholder bonus: 0.35 + 0.2 = 0.55
+      expect(empathyFit).toBe(0.55);
+    });
+
+    it('should calculate empathy fit for climate-focused profile', () => {
+      const contentTags = { 
+        stakeholders: ['affected_communities', 'environmental_scientists'], 
+        topics: [], 
+        domain: 'climate' 
+      };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'climate_focused');
+      
+      // Climate profile: affected_communities: 0.4, environmental_scientists: 0.3
+      // Average: (0.4 + 0.3) / 2 = 0.35
+      // With stakeholder bonus: 0.35 + 0.2 = 0.55
+      expect(empathyFit).toBe(0.55);
+    });
+
+    it('should cap empathy fit at 1.0', () => {
+      const contentTags = { 
+        stakeholders: ['affected_communities', 'environmental_scientists', 'policymakers', 'general_public'], 
+        topics: [], 
+        domain: 'climate' 
+      };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'climate_focused');
+      
+      expect(empathyFit).toBeLessThanOrEqual(1.0);
+    });
+
+    it('should fallback to default profile for unknown profile', () => {
+      const contentTags = { 
+        stakeholders: ['general_public'], 
+        topics: [], 
+        domain: 'general' 
+      };
+      const empathyFit = empathyService.calculateEmpathyFit(contentTags, 'unknown_profile');
+      
+      // Should use default profile: general_public: 0.4
+      // With stakeholder bonus: 0.4 + 0.1 = 0.5
+      expect(empathyFit).toBe(0.5);
+    });
+  });
+
+  describe('extractContentTags', () => {
+    it('should extract stakeholders from metadata', () => {
+      const content = 'Some content';
+      const metadata = { 
+        stakeholders: ['experts', 'policymakers'],
+        domain: 'technology'
+      };
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      expect(tags.stakeholders).toEqual(['experts', 'policymakers']);
+      expect(tags.domain).toBe('technology');
+    });
+
+    it('should extract stakeholders from content keywords', () => {
+      const content = 'Expert researchers and scientists work with government officials to help vulnerable communities.';
+      const metadata = {};
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      expect(tags.stakeholders).toContain('experts');
+      expect(tags.stakeholders).toContain('policymakers');
+      expect(tags.stakeholders).toContain('affected_communities');
+    });
+
+    it('should extract topics from content', () => {
+      const content = 'Climate change and global warming require new technology solutions for health and medical treatment.';
+      const metadata = {};
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      expect(tags.topics).toContain('climate');
+      expect(tags.topics).toContain('technology');
+      expect(tags.topics).toContain('health');
+    });
+
+    it('should handle single stakeholder in metadata', () => {
+      const content = 'Some content';
+      const metadata = { 
+        stakeholders: 'experts',
+        domain: 'science'
+      };
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      expect(tags.stakeholders).toEqual(['experts']);
+    });
+
+    it('should avoid duplicate stakeholders', () => {
+      const content = 'Expert scientists and researchers work on scientific research.';
+      const metadata = { stakeholders: ['experts'] };
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      // Should not have duplicate 'experts'
+      const expertCount = tags.stakeholders!.filter(s => s === 'experts').length;
+      expect(expertCount).toBe(1);
+    });
+
+    it('should set default domain when not provided', () => {
+      const content = 'Some content';
+      const metadata = {};
+      
+      const tags = empathyService.extractContentTags(content, metadata);
+      
+      expect(tags.domain).toBe('general');
+    });
+  });
+
+  describe('getAvailableProfiles', () => {
+    it('should return list of available profile names', () => {
+      const profiles = empathyService.getAvailableProfiles();
+      
+      expect(profiles).toContain('default');
+      expect(profiles).toContain('climate_focused');
+      expect(profiles.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('getProfile', () => {
+    it('should return profile for valid name', () => {
+      const profile = empathyService.getProfile('default');
+      
+      expect(profile).toBeDefined();
+      expect(profile!.name).toBe('Default Profile');
+      expect(profile!.stakeholders).toHaveProperty('general_public');
+    });
+
+    it('should return null for invalid profile name', () => {
+      const profile = empathyService.getProfile('nonexistent');
+      
+      expect(profile).toBeNull();
+    });
+  });
+});

--- a/api/src/services/empathy.ts
+++ b/api/src/services/empathy.ts
@@ -1,0 +1,176 @@
+import { join } from 'path';
+import { readFileSync } from 'fs';
+
+export interface EmpathyProfile {
+  name: string;
+  stakeholders: Record<string, number>;
+}
+
+export interface EmpathyProfiles {
+  [key: string]: EmpathyProfile;
+}
+
+export interface ContentTags {
+  stakeholders?: string[];
+  topics?: string[];
+  domain?: string;
+}
+
+export class EmpathyService {
+  private profiles: EmpathyProfiles = {};
+
+  constructor() {
+    this.loadProfiles();
+  }
+
+  /**
+   * Load empathy profiles from configuration file
+   */
+  private loadProfiles(): void {
+    try {
+      // Try relative path from api directory first, then absolute path
+      let profilesPath = join(process.cwd(), '../data/profiles/empathy-profiles.json');
+      try {
+        const profilesData = readFileSync(profilesPath, 'utf-8');
+        this.profiles = JSON.parse(profilesData);
+        return;
+      } catch {
+        // Fallback to root-relative path
+        profilesPath = join(process.cwd(), 'data/profiles/empathy-profiles.json');
+        const profilesData = readFileSync(profilesPath, 'utf-8');
+        this.profiles = JSON.parse(profilesData);
+        return;
+      }
+    } catch (error) {
+      console.warn('Failed to load empathy profiles, using defaults:', error);
+      this.profiles = {
+        default: {
+          name: 'Default Profile',
+          stakeholders: {
+            general_public: 0.4,
+            experts: 0.3,
+            policymakers: 0.2,
+            affected_communities: 0.1
+          }
+        },
+        climate_focused: {
+          name: 'Climate-Focused Profile',
+          stakeholders: {
+            affected_communities: 0.4,
+            environmental_scientists: 0.3,
+            policymakers: 0.2,
+            general_public: 0.1
+          }
+        }
+      };
+    }
+  }
+
+  /**
+   * Calculate empathy fit score based on content tags and selected profile
+   */
+  calculateEmpathyFit(
+    contentTags: ContentTags,
+    profileName: string = 'default'
+  ): number {
+    const profile = this.profiles[profileName] || this.profiles.default;
+    
+    if (!contentTags.stakeholders || contentTags.stakeholders.length === 0) {
+      // If no stakeholder tags, return neutral empathy fit
+      return 0.5;
+    }
+
+    let totalFit = 0;
+    let matchedStakeholders = 0;
+
+    // Calculate weighted empathy fit based on stakeholder overlap
+    for (const stakeholder of contentTags.stakeholders) {
+      const normalizedStakeholder = stakeholder.toLowerCase().replace(/\s+/g, '_');
+      
+      if (profile.stakeholders[normalizedStakeholder]) {
+        totalFit += profile.stakeholders[normalizedStakeholder];
+        matchedStakeholders++;
+      }
+    }
+
+    if (matchedStakeholders === 0) {
+      // No matching stakeholders, return low empathy fit
+      return 0.2;
+    }
+
+    // Normalize by number of matched stakeholders and apply scaling
+    const avgFit = totalFit / matchedStakeholders;
+    
+    // Scale to [0, 1] range with some boost for multiple stakeholder matches
+    const stakeholderBonus = Math.min(matchedStakeholders * 0.1, 0.3);
+    return Math.min(avgFit + stakeholderBonus, 1.0);
+  }
+
+  /**
+   * Extract content tags from evidence metadata and content
+   */
+  extractContentTags(content: string, metadata: any): ContentTags {
+    const tags: ContentTags = {
+      stakeholders: [],
+      topics: [],
+      domain: metadata?.domain || 'general'
+    };
+
+    // Extract stakeholders from metadata if available
+    if (metadata?.stakeholders) {
+      tags.stakeholders = Array.isArray(metadata.stakeholders) 
+        ? metadata.stakeholders 
+        : [metadata.stakeholders];
+    }
+
+    // Extract stakeholders from content using keyword matching
+    const stakeholderKeywords = {
+      'general_public': ['public', 'citizens', 'people', 'community', 'society'],
+      'experts': ['expert', 'scientist', 'researcher', 'specialist', 'professional'],
+      'policymakers': ['policy', 'government', 'regulation', 'law', 'official'],
+      'affected_communities': ['affected', 'vulnerable', 'marginalized', 'impacted', 'disadvantaged'],
+      'environmental_scientists': ['environmental', 'climate', 'ecology', 'conservation'],
+      'healthcare_workers': ['healthcare', 'medical', 'doctor', 'nurse', 'patient']
+    };
+
+    const contentLower = content.toLowerCase();
+    
+    for (const [stakeholder, keywords] of Object.entries(stakeholderKeywords)) {
+      if (keywords.some(keyword => contentLower.includes(keyword))) {
+        if (!tags.stakeholders!.includes(stakeholder)) {
+          tags.stakeholders!.push(stakeholder);
+        }
+      }
+    }
+
+    // Extract topics from content
+    const topicKeywords = {
+      'climate': ['climate', 'global warming', 'carbon', 'emissions'],
+      'technology': ['technology', 'digital', 'AI', 'software', 'computer'],
+      'health': ['health', 'medical', 'disease', 'treatment', 'wellness'],
+      'education': ['education', 'learning', 'school', 'university', 'teaching']
+    };
+
+    for (const [topic, keywords] of Object.entries(topicKeywords)) {
+      if (keywords.some(keyword => contentLower.includes(keyword))) {
+        tags.topics!.push(topic);
+      }
+    }
+
+    return tags;
+  }
+
+  /**
+   * Get available empathy profiles
+   */
+  getAvailableProfiles(): string[] {
+    return Object.keys(this.profiles);
+  }
+
+  /**
+   * Get specific empathy profile
+   */
+  getProfile(profileName: string): EmpathyProfile | null {
+    return this.profiles[profileName] || null;
+  }
+}

--- a/api/src/services/ranking.test.ts
+++ b/api/src/services/ranking.test.ts
@@ -1,51 +1,198 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { RankingService } from './ranking.js';
 
 describe('RankingService', () => {
-  const rankingService = new RankingService();
+  let rankingService: RankingService;
+
+  beforeEach(() => {
+    rankingService = new RankingService();
+  });
 
   it('should create instance', () => {
     expect(rankingService).toBeDefined();
   });
 
-  it('should rank evidence with baseline mode', async () => {
-    const query = 'test query about climate change';
-    const k = 2;
+  describe('rankBaseline', () => {
+    it('should rank evidence with baseline mode', async () => {
+      const query = 'test query about climate change';
+      const k = 2;
 
-    const result = await rankingService.rankBaseline(query, k);
-    
-    expect(result).toBeDefined();
-    expect(result).toHaveProperty('evidence');
-    expect(result).toHaveProperty('answer');
-    expect(result).toHaveProperty('confidence');
-    expect(result).toHaveProperty('nullness');
-    expect(Array.isArray(result.evidence)).toBe(true);
-    expect(result.evidence.length).toBeLessThanOrEqual(k);
+      const result = await rankingService.rankBaseline(query, k);
+      
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('evidence');
+      expect(result).toHaveProperty('answer');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('nullness');
+      expect(result.mode).toBe('baseline');
+      expect(Array.isArray(result.evidence)).toBe(true);
+      expect(result.evidence.length).toBeLessThanOrEqual(k);
+    });
+
+    it('should use cosine score as final score in baseline mode', async () => {
+      const result = await rankingService.rankBaseline('test query', 5);
+      
+      for (const evidence of result.evidence) {
+        expect(evidence.score).toBe(evidence.cosineScore);
+        expect(evidence.empathyFit).toBe(0.0); // Not used in baseline
+      }
+    });
+
+    it('should return evidence sorted by cosine score', async () => {
+      const result = await rankingService.rankBaseline('test query', 5);
+      
+      for (let i = 1; i < result.evidence.length; i++) {
+        expect(result.evidence[i-1].cosineScore).toBeGreaterThanOrEqual(
+          result.evidence[i].cosineScore
+        );
+      }
+    });
   });
 
-  it('should rank evidence with VOLaM mode', async () => {
-    const query = 'test query about artificial intelligence';
-    const k = 2;
-    const alpha = 0.6;
-    const beta = 0.3;
-    const gamma = 0.1;
+  describe('rankWithVOLaM', () => {
+    it('should rank evidence with VOLaM mode', async () => {
+      const query = 'test query about climate change';
+      const k = 2;
+      const alpha = 0.6;
+      const beta = 0.3;
+      const gamma = 0.1;
 
-    const result = await rankingService.rankWithVOLaM(query, k, alpha, beta, gamma);
-    
-    expect(result).toBeDefined();
-    expect(result).toHaveProperty('evidence');
-    expect(result).toHaveProperty('answer');
-    expect(result).toHaveProperty('confidence');
-    expect(result).toHaveProperty('nullness');
-    expect(Array.isArray(result.evidence)).toBe(true);
-    expect(result.evidence.length).toBeLessThanOrEqual(k);
-    
-    // Check that evidence has VOLaM-specific properties
-    if (result.evidence.length > 0) {
-      expect(result.evidence[0]).toHaveProperty('empathyFit');
-      expect(result.evidence[0]).toHaveProperty('cosineScore');
-      expect(result.evidence[0]).toHaveProperty('nullness');
-    }
+      const result = await rankingService.rankWithVOLaM(query, k, alpha, beta, gamma);
+      
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('evidence');
+      expect(result).toHaveProperty('answer');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('nullness');
+      expect(result).toHaveProperty('parameters');
+      expect(result).toHaveProperty('empathyProfile');
+      expect(result.mode).toBe('volam');
+      expect(Array.isArray(result.evidence)).toBe(true);
+      expect(result.evidence.length).toBeLessThanOrEqual(k);
+    });
+
+    it('should calculate empathy fit for each evidence piece', async () => {
+      const result = await rankingService.rankWithVOLaM('climate policy query', 3);
+      
+      for (const evidence of result.evidence) {
+        expect(evidence.empathyFit).toBeGreaterThan(0);
+        expect(evidence.empathyFit).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('should calculate VOLaM scores using α·cosine + β·(1−nullness) + γ·empathy_fit', async () => {
+      const alpha = 0.5;
+      const beta = 0.3;
+      const gamma = 0.2;
+      
+      const result = await rankingService.rankWithVOLaM('test query', 3, alpha, beta, gamma);
+      
+      for (const evidence of result.evidence) {
+        const expectedScore = alpha * evidence.cosineScore + 
+                            beta * (1 - evidence.nullness) + 
+                            gamma * evidence.empathyFit;
+        
+        expect(evidence.score).toBeCloseTo(expectedScore, 5);
+      }
+    });
+
+    it('should sort evidence by VOLaM score in descending order', async () => {
+      const result = await rankingService.rankWithVOLaM('test query', 3);
+      
+      for (let i = 1; i < result.evidence.length; i++) {
+        expect(result.evidence[i-1].score).toBeGreaterThanOrEqual(
+          result.evidence[i].score
+        );
+      }
+    });
+
+    it('should use different empathy profiles', async () => {
+      const defaultResult = await rankingService.rankWithVOLaM('climate query', 3, 0.6, 0.3, 0.1, 'default');
+      const climateResult = await rankingService.rankWithVOLaM('climate query', 3, 0.6, 0.3, 0.1, 'climate_focused');
+      
+      expect(defaultResult.empathyProfile).toBe('default');
+      expect(climateResult.empathyProfile).toBe('climate_focused');
+      
+      // Empathy fits should be different for different profiles
+      const defaultEmpathy = defaultResult.evidence.map(e => e.empathyFit);
+      const climateEmpathy = climateResult.evidence.map(e => e.empathyFit);
+      
+      expect(defaultEmpathy).not.toEqual(climateEmpathy);
+    });
+
+    it('should include parameters in result', async () => {
+      const alpha = 0.7;
+      const beta = 0.2;
+      const gamma = 0.1;
+      
+      const result = await rankingService.rankWithVOLaM('test', 2, alpha, beta, gamma);
+      
+      expect(result.parameters).toEqual({ alpha, beta, gamma });
+    });
+
+    it('should handle tie-breaking by cosine similarity', async () => {
+      // This test verifies the tie-breaking logic exists
+      // In practice, exact ties are rare with real data
+      const result = await rankingService.rankWithVOLaM('test query', 3);
+      
+      // Verify sorting logic is applied
+      expect(result.evidence).toBeDefined();
+      expect(result.evidence.length).toBeGreaterThan(0);
+    });
+
+    it('should use default parameters when not specified', async () => {
+      const result = await rankingService.rankWithVOLaM('test query');
+      
+      expect(result.parameters).toEqual({
+        alpha: 0.6,
+        beta: 0.3,
+        gamma: 0.1
+      });
+      expect(result.empathyProfile).toBe('default');
+    });
+
+    it('should validate parameter ranges', async () => {
+      // Test with extreme parameters
+      const result = await rankingService.rankWithVOLaM('test', 2, 1.0, 0.0, 0.0);
+      
+      expect(result.parameters).toEqual({
+        alpha: 1.0,
+        beta: 0.0,
+        gamma: 0.0
+      });
+      
+      // With alpha=1, beta=0, gamma=0, VOLaM score should equal cosine score
+      for (const evidence of result.evidence) {
+        expect(evidence.score).toBeCloseTo(evidence.cosineScore, 5);
+      }
+    });
+  });
+
+  describe('VOLaM scoring formula', () => {
+    it('should prioritize certainty when beta is high', async () => {
+      const highBetaResult = await rankingService.rankWithVOLaM('test', 3, 0.1, 0.8, 0.1);
+      
+      // Evidence with lower nullness (higher certainty) should rank higher
+      const sortedByNullness = [...highBetaResult.evidence].sort((a, b) => a.nullness - b.nullness);
+      const actualOrder = highBetaResult.evidence;
+      
+      // First evidence should have relatively low nullness
+      expect(actualOrder[0].nullness).toBeLessThanOrEqual(sortedByNullness[1].nullness);
+    });
+
+    it('should prioritize empathy when gamma is high', async () => {
+      const highGammaResult = await rankingService.rankWithVOLaM('climate policy', 3, 0.1, 0.1, 0.8, 'climate_focused');
+      
+      // Evidence with higher empathy fit should rank higher
+      expect(highGammaResult.evidence[0].empathyFit).toBeGreaterThan(0);
+    });
+
+    it('should prioritize cosine similarity when alpha is high', async () => {
+      const highAlphaResult = await rankingService.rankWithVOLaM('test', 3, 0.9, 0.05, 0.05);
+      
+      // Top evidence should have high cosine scores
+      expect(highAlphaResult.evidence[0].cosineScore).toBeGreaterThan(0.5);
+    });
   });
 });


### PR DESCRIPTION
- Add EmpathyService for calculating empathy_fit based on content tags and stakeholder profiles
- Update RankingService to use real empathy calculation in VOLaM mode
- Implement tie-breaking by cosine similarity for equal VOLaM scores
- Add comprehensive unit tests for empathy service and VOLaM scoring
- Support configurable α/β/γ parameters and empathy profiles
- VOLaM score formula: αcosine + β(1nullness) + γempathy_fit

Fixes #8

# Pull Request

## Description
Brief description of the changes in this PR.

## Related Issue
Fixes #(issue number)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Testing
- [ ] Unit tests pass (`npm run test`)
- [ ] Linting passes (`npm run lint`)
- [ ] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manual testing completed (if applicable)

## VOLaM-RAG Specific
- [ ] Evaluation scripts run successfully (if applicable)
- [ ] API endpoints tested (if applicable)
- [ ] UI components tested (if applicable)
- [ ] Data/corpus changes documented (if applicable)

## Checklist
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Additional Notes
Any additional information that reviewers should know.
